### PR TITLE
fix: use npm publish and set registry to fix CI publish 404

### DIFF
--- a/bin/publish-npm
+++ b/bin/publish-npm
@@ -2,6 +2,8 @@
 
 set -eux
 
+# Auth and registry for npm (used for npm view and npm publish)
+npm config set registry https://registry.npmjs.org/
 npm config set '//registry.npmjs.org/:_authToken' "$NPM_TOKEN"
 
 yarn build
@@ -58,4 +60,4 @@ else
 fi
 
 # Publish with the appropriate tag
-yarn publish --tag "$TAG"
+npm publish --tag "$TAG"


### PR DESCRIPTION
Theory is: auth was set for registry.npmjs.org only. Yarn was using registry.yarnpkg.com. In .npmrc, auth is per host, so the token wasn’t sent and the registry responded with 404 for the unauthenticated publish. Not 100% sure but should be safe to change